### PR TITLE
Improve resvg vendoring.

### DIFF
--- a/vendor/resvg/Makefile
+++ b/vendor/resvg/Makefile
@@ -1,0 +1,19 @@
+RELEASE_VERSION  = 0.45.1
+RELEASE_BASENAME = resvg-$(RELEASE_VERSION)
+RELEASE_ARCHIVE  = $(RELEASE_BASENAME).tar.xz
+
+.PHONY: all clean
+
+all: libresvg.a
+
+clean:
+	-@rm -rf "$(RELEASE_BASENAME)" 2>/dev/null
+	-@rm "$(RELEASE_ARCHIVE)" 2>/dev/null
+
+libresvg.a: $(RELEASE_ARCHIVE)
+	@tar -xf $<
+	@cargo build "--manifest-path=$(RELEASE_BASENAME)/Cargo.toml" --release --all
+	@mv "$(RELEASE_BASENAME)/target/release/libresvg.a" "$@"
+
+$(RELEASE_ARCHIVE):
+	@wget "https://github.com/linebender/resvg/releases/download/v$(RELEASE_VERSION)/$(RELEASE_ARCHIVE)"

--- a/vendor/resvg/resvg.odin
+++ b/vendor/resvg/resvg.odin
@@ -15,7 +15,20 @@ transform :: struct {
 	a, b, c, d, e, f: c.float,
 }
 
-foreign import resvg "system:libresvg.a"
+@(private)
+LIB :: (
+    "libresvg.a"         when #exists("libresvg.a") else
+    "system:libresvg.a"  when #exists("/usr/lib/libresvg.a") else
+    ""
+)
+
+when LIB == "" {
+    #panic("Could not find the compiled resvg lib. It can be compiled by running `make -C \"vendor/resvg\"`")
+}
+
+foreign import resvg {
+    LIB when LIB != "" else "system:libresvg.a",
+}
 
 @(default_calling_convention = "c", link_prefix = "resvg_")
 foreign resvg {


### PR DESCRIPTION
Currently resvg is expected to exist already compiled and installed in the system, but installing through the package manager on Arch does not resolve this. This change allows an alternate approach.

First it's checked whether libresvg.a exists locally and if so uses that. Otherwise the system is checked for libresvg.a (/usr/lib is the expected installation path in this case). If either of those fail a panic is raised that informs the user how to build resvg.

A Makefile is provided to allow acquiring and building resvg. The process is similar to the one used by ci/Dockerfile.